### PR TITLE
Bug 471095 - Close project preview before job finishes results in SWT…

### DIFF
--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Ian Stewart-Binks (Red Hat, Inc.) - Bug 471095
+ */
+
 package org.eclipse.buildship.ui
 
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
@@ -1,0 +1,94 @@
+package org.eclipse.buildship.ui
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell
+import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable
+import org.eclipse.swtbot.swt.finder.results.VoidResult
+import org.eclipse.swtbot.swt.finder.results.BoolResult
+import org.eclipse.ui.PlatformUI
+import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.swt.widgets.Display
+
+class SWTBotTestHelper {
+    static SWTWorkbenchBot swtBot;
+
+    public static SWTWorkbenchBot getBot() {
+        if (swtBot == null) {
+            return new SWTWorkbenchBot()
+        }
+        return swtBot
+    }
+
+    private static void closeWelcomePageIfAny() throws Exception {
+        try {
+            SWTBotView view = getBot().activeView()
+            if (view.getTitle().equals("Welcome")) {
+                view.close()
+            }
+        } catch (WidgetNotFoundException e) {
+            UiPlugin.logger().error("Failed to initialize SWTBot test.", e)
+        }
+    }
+
+    public static void closeAllShellsExceptTheApplicationShellAndForceShellActivation() {
+        SWTWorkbenchBot bot = getBot()
+
+        // in case a UI test fails some shells might not be closed properly, therefore we close
+        // these here and log it
+        SWTBotShell[] shells = bot.shells()
+        for (SWTBotShell swtBotShell : shells) {
+            if (swtBotShell.isOpen() && !isEclipseApplicationShell(swtBotShell)) {
+                bot.captureScreenshot(swtBotShell.getText() + " NotClosed.jpg")
+                UiPlugin.logger().warn(swtBotShell.getText() + " was not closed properly.")
+                swtBotShell.close()
+            }
+        }
+
+        // http://wiki.eclipse.org/SWTBot/Troubleshooting#No_active_Shell_when_running_SWTBot_tests_in_Xvfb
+        UIThreadRunnable.syncExec(new VoidResult() {
+
+                    @Override
+                    public void run() {
+                        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell().forceActive()
+                    }
+                })
+    }
+
+    public static boolean isEclipseApplicationShell(final SWTBotShell swtBotShell) {
+        return UIThreadRunnable.syncExec(new BoolResult() {
+
+                    @Override
+                    public Boolean run() {
+                        return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell().equals(swtBotShell.widget)
+                    }
+                })
+    }
+
+    protected static void waitForJobsToFinish() {
+        while (!Job.getJobManager().isIdle()) {
+            delay(500)
+        }
+    }
+
+    private static void delay(long waitTimeMillis) {
+        Display display = Display.getCurrent()
+        if (display != null) {
+            long endTimeMillis = System.currentTimeMillis() + waitTimeMillis
+            while (System.currentTimeMillis() < endTimeMillis) {
+                if (!display.readAndDispatch()) {
+                    display.sleep()
+                }
+            }
+            display.update()
+        } else {
+            try {
+                Thread.sleep(waitTimeMillis)
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+    }
+
+}

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Ian Stewart-Binks (Red Hat, Inc.) - Bug 471095
+ */
+
 package org.eclipse.buildship.ui.wizard.project
 
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
@@ -1,0 +1,76 @@
+package org.eclipse.buildship.ui.wizard.project
+
+import org.eclipse.swtbot.eclipse.finder.waits.Conditions
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.buildship.core.CorePlugin
+import org.eclipse.buildship.core.Logger
+import org.eclipse.buildship.ui.SWTBotTestHelper
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import org.eclipse.buildship.ui.test.fixtures.TestEnvironment
+import org.eclipse.core.runtime.jobs.Job
+
+
+class ProjectPreviewWizardPageUiTest extends Specification {
+    SWTWorkbenchBot bot = SWTBotTestHelper.getBot()
+
+    @Rule
+    TemporaryFolder tempFolder
+    File location
+
+    def setup() {
+        SWTBotTestHelper.closeAllShellsExceptTheApplicationShellAndForceShellActivation()
+    }
+
+    def setupSpec() {
+        SWTBotTestHelper.closeWelcomePageIfAny()
+    }
+
+    def "Stop preview and close import wizard before import job finishes"() {
+        given:
+        Logger logger = Mock()
+        TestEnvironment.registerService(Logger, logger)
+        location = tempFolder.newFolder("new-folder")
+
+        new File(location.toString() + "/build.gradle").withWriter('utf-8') { writer ->
+            writer.writeLine "Thread.sleep(5000)"
+            writer.writeLine "task takesLongTimeToLoad {"
+            writer.writeLine "    Thread.sleep(5000)"
+            writer.writeLine "    doLast {"
+            writer.writeLine "        Thread.sleep(5000)"
+            writer.writeLine "    }"
+            writer.writeLine "}"
+        }
+
+        CorePlugin.workspaceOperations().createProject('project-name', location, [], [], new NullProgressMonitor())
+
+        when:
+        startImportPreviewAndCancelWizard()
+        SWTBotTestHelper.waitForJobsToFinish()
+
+        then:
+        0 * logger.error(_, _)
+
+        cleanup:
+        TestEnvironment.cleanup()
+    }
+
+    private void startImportPreviewAndCancelWizard() {
+        bot.menu("File").menu("Import...").click()
+        SWTBotShell shell = bot.shell("Import")
+        shell.activate()
+        bot.waitUntil(Conditions.shellIsActive("Import"))
+        bot.tree().expandNode("Gradle").select("Gradle Project")
+        bot.button("Next >").click()
+        bot.button("Next >").click()
+        bot.textWithLabel("Project root directory").setText(location.toString())
+        bot.button("Next >").click()
+        bot.button("Next >").click()
+        bot.toolbarButtonWithTooltip("Cancel Operation").click()
+        bot.button("Cancel").click()
+    }
+
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
@@ -23,6 +23,8 @@ import com.gradleware.tooling.toolingmodel.OmniGradleBuildStructure;
 import com.gradleware.tooling.toolingmodel.OmniGradleProjectStructure;
 import com.gradleware.tooling.toolingmodel.util.Pair;
 import com.gradleware.tooling.toolingutils.binding.Property;
+
+import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.GradlePluginsRuntimeException;
 import org.eclipse.buildship.core.gradle.Limitations;
 import org.eclipse.buildship.core.i18n.CoreMessages;
@@ -42,6 +44,7 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Font;
@@ -353,20 +356,32 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
 
                 @Override
                 public void run() {
-                    // update Gradle user home
-                    if (buildEnvironment.getGradle().getGradleUserHome().isPresent()) {
-                        String gradleUserHome = buildEnvironment.getGradle().getGradleUserHome().get().getAbsolutePath();
-                        ProjectPreviewWizardPage.this.gradleUserHomeLabel.setText(gradleUserHome);
+                    try {
+                        if (!ProjectPreviewWizardPage.this.gradleUserHomeLabel.isDisposed()) {
+                            // update Gradle user home
+                            if (buildEnvironment.getGradle().getGradleUserHome().isPresent()) {
+                                String gradleUserHome = buildEnvironment.getGradle().getGradleUserHome().get().getAbsolutePath();
+                                ProjectPreviewWizardPage.this.gradleUserHomeLabel.setText(gradleUserHome);
+                            }
+                        }
+
+                        if (!ProjectPreviewWizardPage.this.gradleVersionLabel.isDisposed()) {
+                            // update Gradle version
+                            String gradleVersion = buildEnvironment.getGradle().getGradleVersion();
+                            ProjectPreviewWizardPage.this.gradleVersionLabel.setText(gradleVersion);
+                            updateGradleVersionWarningLabel();
+                        }
+
+
+                        if (!ProjectPreviewWizardPage.this.javaHomeLabel.isDisposed()) {
+                            // update Java home
+                            String javaHome = buildEnvironment.getJava().getJavaHome().getAbsolutePath();
+                            ProjectPreviewWizardPage.this.javaHomeLabel.setText(javaHome);
+                        }
+                    } catch (SWTException e) {
+                        String message = String.format("Failed to properly close ProjectPreviewWizardPage.");
+                        CorePlugin.logger().error(message, e);
                     }
-
-                    // update Gradle version
-                    String gradleVersion = buildEnvironment.getGradle().getGradleVersion();
-                    ProjectPreviewWizardPage.this.gradleVersionLabel.setText(gradleVersion);
-                    updateGradleVersionWarningLabel();
-
-                    // update Java home
-                    String javaHome = buildEnvironment.getJava().getJavaHome().getAbsolutePath();
-                    ProjectPreviewWizardPage.this.javaHomeLabel.setText(javaHome);
                 }
             });
         }
@@ -376,14 +391,21 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
 
                 @Override
                 public void run() {
-                    ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
+                    try {
+                        if (!ProjectPreviewWizardPage.this.projectPreviewTree.isDisposed()) {
+                              ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
 
-                    // populate the tree from the build structure
-                    OmniGradleProjectStructure rootProject = buildStructure.getRootProject();
-                    TreeItem rootTreeItem = new TreeItem(ProjectPreviewWizardPage.this.projectPreviewTree, SWT.NONE);
-                    rootTreeItem.setExpanded(true);
-                    rootTreeItem.setText(rootProject.getName());
-                    populateRecursively(rootProject, rootTreeItem);
+                              // populate the tree from the build structure
+                              OmniGradleProjectStructure rootProject = buildStructure.getRootProject();
+                              TreeItem rootTreeItem = new TreeItem(ProjectPreviewWizardPage.this.projectPreviewTree, SWT.NONE);
+                              rootTreeItem.setExpanded(true);
+                              rootTreeItem.setText(rootProject.getName());
+                              populateRecursively(rootProject, rootTreeItem);
+                        }
+                    } catch (SWTException e) {
+                        String message = String.format("Failed to properly close ProjectPreviewWizardPage.");
+                        CorePlugin.logger().error(message, e);
+                    }
                 }
             });
         }
@@ -393,7 +415,14 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
 
                 @Override
                 public void run() {
-                    ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
+                    try {
+                        if (!ProjectPreviewWizardPage.this.projectPreviewTree.isDisposed()) {
+                            ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
+                        }
+                    } catch (SWTException e) {
+                        String message = String.format("Failed to properly close ProjectPreviewWizardPage.");
+                        CorePlugin.logger().error(message, e);
+                    }
                 }
             });
         }


### PR DESCRIPTION
…Exception

Signed-off-by: Ian Stewart-Binks <istewart@redhat.com>

@fbricon, Can you take a look at this before I make a PR on upstream? Specifically, I'm not sure if the way I approached refactoring the SWTBot tests into a new groovy module is the best approach. This is nearly identical to what we did for Smart Import. Ultimately, it will be up to the Gradle tooling team to decide which approach is best, but I want to make sure this is pristine before it goes out our doors. I'm not yet convinced that it's pristine, and your feedback means a lot. Thanks!